### PR TITLE
peerDependency to webpack 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "loader-utils": "^0.2.15",
     "qs": "^6.2.0"
   },
+  "peerDependencies": {
+    "webpack": "1"
+  },
   "author": "jl- <i.dragonxx@gmail.com> (http://jlxy.cz)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
As this plugin only supports webpack 1, it should state this in the peerDependencies. (For usage see: https://github.com/ampedandwired/html-webpack-plugin/blob/master/package.json).